### PR TITLE
Adds Remove Note action

### DIFF
--- a/include/PianoRoll.h
+++ b/include/PianoRoll.h
@@ -229,6 +229,7 @@ private:
 	enum Actions
 	{
 		ActionNone,
+		ActionRemoveNote,
 		ActionMoveNote,
 		ActionResizeNote,
 		ActionSelectNotes,
@@ -425,8 +426,6 @@ private:
 	EditModes m_editMode;
 	EditModes m_ctrlMode; // mode they were in before they hit ctrl
 	EditModes m_knifeMode; // mode they where in before entering knife mode
-
-	bool m_mouseDownRight; //true if right click is being held down
 
 	TimeLineWidget * m_timeLine;
 	bool m_scrollBack;

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2336,31 +2336,22 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent* me)
 			// Make sure vector is not empty
 			if (nv.size() > 0)
 			{
-				const Note* closest = nullptr;
-				int closestDist = 9999999;
+				Note* closest = nullptr;
+				// closestDist will be compared with all other note's distances to find
+				// the smallest, so we can set it to the first note's distance.
+				int closestDist = std::abs(nv.first()->pos().getTicks() - ticksMiddle);
 				// If we caught multiple notes and we're not editing a
 				// selection, find the closest...
 				if (nv.size() > 1 && !isSelection())
 				{
-					for (const Note* i : nv)
+					for (Note* i : nv)
 					{
-						const int dist = qAbs(i->pos().getTicks() - ticksMiddle);
-						if (dist < closestDist) { closest = i; closestDist = dist; }
+						const int dist = std::abs(i->pos().getTicks() - ticksMiddle);
+						if (dist <= closestDist) { closest = i; closestDist = dist; }
 					}
-					// ... then remove all notes from the vector that aren't on the same exact time
-					NoteVector::Iterator it = nv.begin();
-					while (it != nv.end())
-					{
-						const Note* note = *it;
-						if (note->pos().getTicks() != closest->pos().getTicks())
-						{
-							it = nv.erase(it);
-						}
-						else
-						{
-							it++;
-						}
-					}
+					// ... then we clear the vector and add just the closest note
+					nv.clear();
+					nv += closest;
 				}
 				enterValue(&nv);
 			}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2748,29 +2748,27 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 	{
 		case ActionNone:
 		{
-			const int key_num = getKey(mey);
+			const int keyNum = getKey(mey);
 
-			// see if they clicked on the keyboard on the left
-			if (   pra == PianoRollArea::Keys
-				&& key_num != m_lastKey
-				&& leftButton
-			)
+			// See if they clicked on the keyboard on the left
+			if (pra == PianoRollArea::Keys && keyNum != m_lastKey && leftButton)
 			{
-				// clicked on a key, play the note
-				testPlayKey(key_num, ((float) mex) / ((float) m_whiteKeyWidth) * MidiDefaultVelocity, 0);
+				// Clicked on a key, play the note
+				testPlayKey(keyNum, ((float) mex) / ((float) m_whiteKeyWidth) * MidiDefaultVelocity, 0);
 				update();
 				return;
 			}
 
 			Note* const n = noteUnderMouse();
-			// if we're in ModeDraw and holding right button or ModeErase and any
+			// TODO: Removing notes should have an action of its own
+			// If we're in ModeDraw and holding right button or ModeErase and any
 			if (n != nullptr)
 			{
 				switch (m_editMode)
 				{
 					case ModeDraw:
 					{
-						// don't continue if we're not holding right button
+						// Don't continue if we're not holding right button
 						if (!rightButton) { break; }
 					}
 					case ModeErase:
@@ -2786,14 +2784,17 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 				}
 			}
 
-			// set cursor for mouse location
-			if (mey > keyAreaBottom() && mey < noteEditTop())
-			{
-				setCursor(Qt::SizeVerCursor);
-				return;
-			}
+			// Set the appropriate cursor
+			// Default is Arrow Cursor
 			Qt::CursorShape cursorShape = Qt::ArrowCursor;
-			if (n != nullptr)
+			// If we are resizing the edit area, use SizeVerCursor
+			if (pra == PianoRollArea::EditAreaResize)
+			{
+				cursorShape = Qt::SizeVerCursor;
+			}
+			// If we are over a note use SizeAllCursor unless we are
+			// at the tail of the note, then we use SizeHorCursor
+			else if (n != nullptr)
 			{
 				const int noteTailX =
 					(n->pos() + n->length() - m_currentPosition)
@@ -2802,18 +2803,20 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 				cursorShape = atTail ? Qt::SizeHorCursor : Qt::SizeAllCursor;
 			}
 			setCursor(cursorShape);
+			update();
+			return;
 
 			break;
 		}
 		case ActionMoveNote:
 		case ActionResizeNote:
 		{
-			int key_num = getKey( mey );
-			// handle moving notes and resizing them
-			bool replay_note = key_num != m_lastKey
-							&& m_action == ActionMoveNote;
+			int keyNum = getKey(mey);
+			// Handle moving notes and resizing them
+			bool replayNote = keyNum != m_lastKey
+				&& m_action == ActionMoveNote;
 
-			if( replay_note || ( m_action == ActionMoveNote && shiftDown && ! m_startedWithShift ) )
+			if (replayNote || (m_action == ActionMoveNote && shiftDown && ! m_startedWithShift))
 			{
 				pauseTestNotes();
 			}
@@ -2826,10 +2829,13 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 				me->modifiers() & Qt::ControlModifier
 			);
 
-			if( replay_note && m_action == ActionMoveNote && ! ( shiftDown && ! m_startedWithShift ) )
+			if (replayNote && m_action == ActionMoveNote && ! (shiftDown && ! m_startedWithShift))
 			{
-				pauseTestNotes( false );
+				pauseTestNotes(false);
 			}
+
+			update();
+			return;
 
 			break;
 		}
@@ -2838,6 +2844,7 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 			if (leftButton && m_editMode == ModeSelect)
 			{
 				int x = mex - m_whiteKeyWidth;
+				// Handle horizontal scrolling
 				if (x < 0 && m_currentPosition > 0)
 				{
 					x = 0;
@@ -2855,35 +2862,36 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 					m_leftRightScroll->setValue(m_currentPosition + 4);
 				}
 
-				// get tick where mouse is
-				int pos_ticks = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-				m_selectedTick = pos_ticks - m_selectStartTick;
+				// Get tick where mouse is
+				int posTicks = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+				m_selectedTick = posTicks - m_selectStartTick;
+				// Make sure we don't select ticks before the beginning
 				if (m_selectStartTick + m_selectedTick < 0)
 				{
 					m_selectedTick = -m_selectStartTick;
 				}
 
-				// determine if we need to scroll up/down during select mode
+				// Determine if we need to scroll up/down during select mode
 				// because mouse past top/bottom key in current view
-				int key_num = getKey(mey);
-				const int visible_keys = (keyAreaBottom() - keyAreaTop()) / m_keyLineHeight;
-				const int s_key = m_startKey - 1;
+				int keyNum = getKey(mey);
+				const int visibleKeys = (keyAreaBottom() - keyAreaTop()) / m_keyLineHeight;
+				const int bottomKey = m_startKey - 1;
 
-				if (key_num <= s_key)
+				if (mey > keyAreaBottom())
 				{
 					QCursor::setPos(mapToGlobal(QPoint(mex, keyAreaBottom())));
 					m_topBottomScroll->setValue(m_topBottomScroll->value() + 1);
-					key_num = s_key;
+					keyNum = bottomKey;
 				}
-				else if (key_num >= s_key + visible_keys)
+				else if (mey < keyAreaTop())
 				{
 					QCursor::setPos(mapToGlobal(QPoint(mex, keyAreaTop())));
 					m_topBottomScroll->setValue(m_topBottomScroll->value() - 1);
-					key_num = s_key + visible_keys;
+					keyNum = bottomKey + visibleKeys;
 				}
 
-				m_selectedKeys = key_num - m_selectStartKey;
-				if (key_num <= m_selectStartKey) { --m_selectedKeys; }
+				m_selectedKeys = keyNum - m_selectStartKey;
+				if (keyNum <= m_selectStartKey) { --m_selectedKeys; }
 			}
 			update();
 			return;
@@ -2891,105 +2899,112 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 		case ActionChangeNoteProperty:
 		{
 			if (m_editMode != ModeErase
-			    && mey > noteEditTop()
+				&& mey > noteEditTop()
 				&& (leftButton || middleButton || (rightButton && shiftDown))
 			)
 			{
-				// editing note properties
+				// Editing note properties
 
 				// Change notes within a certain pixel range of where
 				// the mouse cursor is
-				int pixel_range = 14;
+				int pixelRange = 14;
 				int x = mex - m_whiteKeyWidth;
 
-				// convert to ticks so that we can check which notes
+				// Convert to ticks so that we can check which notes
 				// are in the range
-				int ticks_start = ( x-pixel_range/2 ) *
-						TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-				int ticks_end = ( x+pixel_range/2 ) *
-						TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+				int ticksStart = (x - pixelRange / 2) *
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+				int ticksEnd = (x + pixelRange / 2) *
+					TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
-				// get note-vector of current pattern
+				// Get note-vector of current pattern
 				const NoteVector & notes = m_pattern->notes();
 
-				// determine what volume/panning to set note to
+				// Determine what volume/panning to set note to
 				// if middle-click, set to defaults
 				volume_t vol = DefaultVolume;
 				panning_t pan = DefaultPanning;
 
-				if( leftButton )
+				// Calculate the value from the mouse position
+				if (leftButton)
 				{
-					vol = qBound<int>( MinVolume,
-									MinVolume +
-									( ( (float)noteEditBottom() ) - ( (float)mey ) ) /
-									( (float)( noteEditBottom() - noteEditTop() ) ) *
-									( MaxVolume - MinVolume ),
-												MaxVolume );
-					pan = qBound<int>( PanningLeft,
-									PanningLeft +
-									( (float)( noteEditBottom() - mey ) ) /
-									( (float)( noteEditBottom() - noteEditTop() ) ) *
-									( (float)( PanningRight - PanningLeft ) ),
-											PanningRight);
+					vol = qBound<int>(
+						MinVolume,
+						MinVolume +
+							(((float)noteEditBottom()) - ((float)mey)) /
+							((float)(noteEditBottom() - noteEditTop())) *
+							(MaxVolume - MinVolume),
+						MaxVolume);
+					pan = qBound<int>(
+						PanningLeft,
+						PanningLeft +
+							((float)(noteEditBottom() - mey)) /
+							((float)(noteEditBottom() - noteEditTop())) *
+							((float)(PanningRight - PanningLeft)),
+						PanningRight);
 				}
 
-				if( m_noteEditMode == NoteEditVolume )
+				// Display the value as text
+				if (m_noteEditMode == NoteEditVolume)
 				{
 					m_lastNoteVolume = vol;
-					showVolTextFloat( vol, me->pos() );
+					showVolTextFloat(vol, me->pos());
 				}
-				else if( m_noteEditMode == NoteEditPanning )
+				else if (m_noteEditMode == NoteEditPanning)
 				{
 					m_lastNotePanning = pan;
-					showPanTextFloat( pan, me->pos() );
+					showPanTextFloat(pan, me->pos());
 				}
 
 				// When alt is pressed we only edit the note under the cursor
 				bool altPressed = me->modifiers() & Qt::AltModifier;
+
 				// We iterate from last note in pattern to the first,
 				// chronologically
-				NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
-				for( int i = 0; i < notes.size(); ++i )
+				NoteVector::ConstIterator it = notes.begin() + notes.size() - 1;
+				for (int i = 0; i < notes.size(); ++i)
 				{
 					Note* n = *it;
 
-					bool isUnderPosition = n->withinRange( ticks_start, ticks_end );
+					bool isUnderPosition = n->withinRange(ticksStart, ticksEnd);
 					// Play note under the cursor
-					if ( isUnderPosition ) { testPlayNote( n ); }
+					if (isUnderPosition) { testPlayNote(n); }
 					// If note is:
 					// Under the cursor, when there is no selection
 					// Selected, and alt is not pressed
 					// Under the cursor, selected, and alt is pressed
-					if ( ( isUnderPosition && !isSelection() ) ||
-						( n->selected() && !altPressed ) ||
-						( isUnderPosition && n->selected() && altPressed )
-						)
+					if
+					(
+						(isUnderPosition && !isSelection()) ||
+						(n->selected() && !altPressed) ||
+						(isUnderPosition && n->selected() && altPressed)
+					)
 					{
-						if( m_noteEditMode == NoteEditVolume )
+						if (m_noteEditMode == NoteEditVolume)
 						{
-							n->setVolume( vol );
+							n->setVolume(vol);
 
 							const int baseVelocity = m_pattern->instrumentTrack()->midiPort()->baseVelocity();
 
-							m_pattern->instrumentTrack()->processInEvent( MidiEvent( MidiKeyPressure, -1, n->key(), n->midiVelocity( baseVelocity ) ) );
+							m_pattern->instrumentTrack()->processInEvent(
+								MidiEvent(MidiKeyPressure, -1, n->key(), n->midiVelocity(baseVelocity)));
 						}
-						else if( m_noteEditMode == NoteEditPanning )
+						else if (m_noteEditMode == NoteEditPanning)
 						{
-							n->setPanning( pan );
-							MidiEvent evt( MidiMetaEvent, -1, n->key(), panningToMidi( pan ) );
-							evt.setMetaEvent( MidiNotePanning );
-							m_pattern->instrumentTrack()->processInEvent( evt );
+							n->setPanning(pan);
+							MidiEvent evt(MidiMetaEvent, -1, n->key(), panningToMidi(pan));
+							evt.setMetaEvent(MidiNotePanning);
+							m_pattern->instrumentTrack()->processInEvent(evt);
 						}
 					}
-					else if( n->isPlaying() && !isSelection() )
+					else if (n->isPlaying() && !isSelection())
 					{
-						// mouse not over this note, stop playing it.
-						m_pattern->instrumentTrack()->pianoModel()->handleKeyRelease( n->key() );
+						// Mouse not over this note, stop playing it.
+						m_pattern->instrumentTrack()->pianoModel()->handleKeyRelease(n->key());
 						pauseChordNotes(n->key());
 
-						n->setIsPlaying( false );
+						n->setIsPlaying(false);
 					}
-
 
 					--it;
 				}
@@ -2997,6 +3012,9 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 				// Emit pattern has changed
 				m_pattern->dataChanged();
 			}
+
+			update();
+			return;
 			break;
 		}
 		case ActionResizeNoteEditArea:
@@ -3009,7 +3027,7 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 				newHeight = height() - KEY_AREA_MIN_HEIGHT -
 					PR_TOP_MARGIN - PR_BOTTOM_MARGIN; // - NOTE_EDIT_RESIZE_BAR
 			}
-			// change m_notesEditHeight and then repaint
+			// Change m_notesEditHeight and then repaint
 			m_notesEditHeight = qMax(NOTE_EDIT_MIN_HEIGHT, newHeight);
 			m_userSetNotesEditHeight = m_notesEditHeight;
 			m_stepRecorderWidget.setBottomMargin(PR_BOTTOM_MARGIN + m_notesEditHeight);
@@ -3017,6 +3035,7 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 			updatePositionLineHeight();
 			repaint();
 			return;
+			break;
 		}
 		case ActionKnife:
 		{
@@ -3024,6 +3043,8 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 			{
 				updateKnifePos(me);
 			}
+			update();
+			return;
 			break;
 		}
 		default:
@@ -3452,8 +3473,6 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 
 	// m_lastMouseX = me->x();
 	// m_lastMouseY = me->y();
-
-	update();
 }
 
 

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -2300,7 +2300,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 
 
 
-void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
+void PianoRoll::mouseDoubleClickEvent(QMouseEvent* me)
 {
 	if (!hasValidPattern()) { return; }
 
@@ -2315,46 +2315,46 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 	{
 		case PianoRollArea::NoteProperties:
 		{
-			// get values for going through notes
-			int pixel_range = 4;
+			// Get values for going through notes
+			int pixelRange = 4;
 			int x = mex - m_whiteKeyWidth;
-			const int ticks_start = (x - pixel_range / 2) *
+			const int ticksStart = (x - pixelRange / 2) *
 						TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-			const int ticks_end = (x + pixel_range / 2) *
+			const int ticksEnd = (x + pixelRange / 2) *
 						TimePos::ticksPerBar() / m_ppb + m_currentPosition;
-			const int ticks_middle = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+			const int ticksMiddle = x * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
-			// go through notes to figure out which one we want to change
+			// Go through notes to figure out which ones we want to change
 			NoteVector nv;
-			for ( Note * i : m_pattern->notes() )
+			for (Note* i : m_pattern->notes())
 			{
-				if( i->withinRange( ticks_start, ticks_end ) || ( i->selected() && !altPressed ) )
+				if (i->withinRange(ticksStart, ticksEnd) || (i->selected() && !altPressed))
 				{
 					nv += i;
 				}
 			}
-			// make sure we're on a note
-			if( nv.size() > 0 )
+			// Make sure vector is not empty
+			if (nv.size() > 0)
 			{
-				const Note * closest = NULL;
-				int closest_dist = 9999999;
-				// if we caught multiple notes and we're not editing a
+				const Note* closest = nullptr;
+				int closestDist = 9999999;
+				// If we caught multiple notes and we're not editing a
 				// selection, find the closest...
-				if( nv.size() > 1 && !isSelection() )
+				if (nv.size() > 1 && !isSelection())
 				{
-					for ( const Note * i : nv )
+					for (const Note* i : nv)
 					{
-						const int dist = qAbs( i->pos().getTicks() - ticks_middle );
-						if( dist < closest_dist ) { closest = i; closest_dist = dist; }
+						const int dist = qAbs(i->pos().getTicks() - ticksMiddle);
+						if (dist < closestDist) { closest = i; closestDist = dist; }
 					}
 					// ... then remove all notes from the vector that aren't on the same exact time
 					NoteVector::Iterator it = nv.begin();
-					while( it != nv.end() )
+					while (it != nv.end())
 					{
-						const Note *note = *it;
-						if( note->pos().getTicks() != closest->pos().getTicks() )
+						const Note* note = *it;
+						if (note->pos().getTicks() != closest->pos().getTicks())
 						{
-							it = nv.erase( it );
+							it = nv.erase(it);
 						}
 						else
 						{
@@ -2362,7 +2362,7 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 						}
 					}
 				}
-				enterValue( &nv );
+				enterValue(&nv);
 			}
 			break;
 		}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -184,7 +184,6 @@ PianoRoll::PianoRoll() :
 	m_lastKey( 0 ),
 	m_editMode( ModeDraw ),
 	m_ctrlMode( ModeDraw ),
-	m_mouseDownRight( false ),
 	m_scrollBack( false ),
 	m_stepRecorderWidget(this, DEFAULT_PR_PPB, PR_TOP_MARGIN, PR_BOTTOM_MARGIN + m_notesEditHeight, WHITE_KEY_WIDTH, 0),
 	m_stepRecorder(*this, m_stepRecorderWidget),
@@ -1864,7 +1863,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 					}
 					else if (rightButton) // erase single note
 					{
-						m_mouseDownRight = true;
+						m_action = ActionRemoveNote;
 						if (n != nullptr)
 						{
 							m_pattern->addJournalCheckPoint();
@@ -1879,6 +1878,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 				case EditModes::ModeErase:
 				{
 					// erase single note
+					m_action = ActionRemoveNote;
 					if (n != nullptr)
 					{
 						m_pattern->addJournalCheckPoint();
@@ -2628,12 +2628,13 @@ void PianoRoll::computeSelectedNotes(bool shift)
 
 
 
-void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
+void PianoRoll::mouseReleaseEvent(QMouseEvent* me)
 {
 	const bool shiftDown = me->modifiers() & Qt::ShiftModifier;
 	const bool rightUp = me->button() & Qt::RightButton;
 	const bool leftUp = me->button() & Qt::LeftButton;
-	bool mustRepaint = false;
+	// Both right and left releases should trigger a repaint
+	bool mustRepaint = rightUp || leftUp;
 
 	s_textFloat->hide();
 
@@ -2645,15 +2646,13 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 
 	if (leftUp)
 	{
-		mustRepaint = true;
-
-		if( m_action == ActionSelectNotes && m_editMode == ModeSelect )
+		if (m_action == ActionSelectNotes && m_editMode == ModeSelect)
 		{
 			// select the notes within the selection rectangle and
 			// then destroy the selection rectangle
 			computeSelectedNotes(shiftDown);
 		}
-		else if( m_action == ActionMoveNote )
+		else if (m_action == ActionMoveNote)
 		{
 			// we moved one or more notes so they have to be
 			// moved properly according to new starting-
@@ -2662,42 +2661,36 @@ void PianoRoll::mouseReleaseEvent( QMouseEvent * me )
 
 		}
 
-		if( m_action == ActionMoveNote || m_action == ActionResizeNote )
+		if (m_action == ActionMoveNote || m_action == ActionResizeNote)
 		{
 			// if we only moved one note, deselect it so we can
 			// edit the notes in the note edit area
-			if( selectionCount() == 1 )
+			if (selectionCount() == 1)
 			{
 				clearSelectedNotes();
 			}
 		}
 	}
 
-	if (rightUp)
-	{
-		m_mouseDownRight = false;
-		mustRepaint = true;
-	}
-
-	if( hasValidPattern() )
+	if (hasValidPattern())
 	{
 		// turn off all notes that are playing
 		stopNotes();
 	}
 
-	m_currentNote = NULL;
+	m_currentNote = nullptr;
 
 	if (m_action != ActionKnife)
 	{
 		m_action = ActionNone;
 	}
 
-	if( m_editMode == ModeDraw )
+	if (m_editMode == ModeDraw)
 	{
-		setCursor( Qt::ArrowCursor );
+		setCursor(Qt::ArrowCursor);
 	}
 
-	if( mustRepaint )
+	if (mustRepaint)
 	{
 		repaint();
 	}
@@ -2736,41 +2729,7 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 	{
 		case ActionNone:
 		{
-			const int keyNum = getKey(mey);
-
-			// See if they clicked on the keyboard on the left
-			if (pra == PianoRollArea::Keys && keyNum != m_lastKey && leftButton)
-			{
-				// Clicked on a key, play the note
-				testPlayKey(keyNum, ((float) mex) / ((float) m_whiteKeyWidth) * MidiDefaultVelocity, 0);
-				update();
-				return;
-			}
-
 			Note* const n = noteUnderMouse();
-			// TODO: Removing notes should have an action of its own
-			// If we're in ModeDraw and holding right button or ModeErase and any
-			if (n != nullptr)
-			{
-				switch (m_editMode)
-				{
-					case ModeDraw:
-					{
-						// Don't continue if we're not holding right button
-						if (!rightButton) { break; }
-					}
-					case ModeErase:
-					{
-						m_pattern->removeNote(n);
-						update();
-						return;
-					}
-					case ModeSelect:
-					case ModeEditDetuning:
-					case ModeEditKnife:
-						break;
-				}
-			}
 
 			// Set the appropriate cursor
 			// Default is Arrow Cursor
@@ -2796,10 +2755,33 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 
 			break;
 		}
+		case ActionRemoveNote:
+		{
+			Note* const n = noteUnderMouse();
+			// If we're in ModeDraw and holding right button or ModeErase and any
+			if (n != nullptr)
+			{
+				if ((m_editMode == ModeDraw && rightButton) ||
+					(m_editMode == ModeErase))
+				{
+					m_pattern->removeNote(n);
+				}
+			}
+
+			update();
+			return;
+
+			break;
+		}
 		case ActionPlayKeys:
 		{
 			const int keyNum = getKey(mey);
-			const int v = static_cast<int>((static_cast<float>(mex) / m_whiteKeyWidth) * MidiDefaultVelocity);
+			// Calculate the velocity to play the key
+			// TODO: Use std::clamp when we have C++17
+			auto vx = std::min(mex, m_whiteKeyWidth);
+			vx = std::max(vx, 0);
+			const int v = static_cast<int>((static_cast<float>(vx) / m_whiteKeyWidth) * MidiDefaultVelocity);
+
 			if (keyNum != m_lastKey)
 			{
 				testPlayKey(keyNum, v, 0);
@@ -2811,7 +2793,10 @@ void PianoRoll::mouseMoveEvent(QMouseEvent * me)
 				m_pattern->instrumentTrack()->pianoModel()->handleKeyPress(keyNum, v);
 				playChordNotes(keyNum, v);
 			}
+			update();
 			return;
+
+			break;
 		}
 		case ActionMoveNote:
 		case ActionResizeNote:
@@ -4376,11 +4361,11 @@ void PianoRoll::paintEvent(QPaintEvent * pe )
 		switch( m_editMode )
 		{
 			case ModeDraw:
-				if( m_mouseDownRight )
+				if (m_action == ActionRemoveNote)
 				{
 					cursor = s_toolErase;
 				}
-				else if( m_action == ActionMoveNote )
+				else if (m_action == ActionMoveNote)
 				{
 					cursor = s_toolMove;
 				}

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -1641,7 +1641,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 		update();
 	}
 
-	const int key_num = getKey(mey);
+	const int keyNum = getKey(mey);
 
 
 	switch (pra)
@@ -1651,15 +1651,15 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 			// reference to last key needed for both
 			// right click (used for copy all keys on note)
 			// and for playing the key when left-clicked
-			//m_lastKey = key_num;
+			//m_lastKey = keyNum;
 
 			if (leftButton)
 			{
 				int v = static_cast<int>((static_cast<float>(mex) / m_whiteKeyWidth) * MidiDefaultVelocity);
-				testPlayKey(key_num, v, 0);
-				//m_pattern->instrumentTrack()->pianoModel()->handleKeyPress(key_num, v);
+				testPlayKey(keyNum, v, 0);
+				//m_pattern->instrumentTrack()->pianoModel()->handleKeyPress(keyNum, v);
 				// if a chord is set, play the chords notes as well:
-				//playChordNotes(key_num, v);
+				//playChordNotes(keyNum, v);
 				//mouseMoveEvent(me);
 				//update();
 			}
@@ -1675,7 +1675,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 		{
 			Note* n = noteUnderMouse(); // TODO: Rename to better name
 			// get tick in which the user clicked
-			const int pos_ticks = (mex - m_whiteKeyWidth) * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
+			const int posTicks = (mex - m_whiteKeyWidth) * TimePos::ticksPerBar() / m_ppb + m_currentPosition;
 
 			switch (m_editMode)
 			{
@@ -1711,27 +1711,27 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 				{
 					if (leftButton)
 					{
-						bool is_new_note = false;
-						Note* created_new_note = nullptr;
+						bool isNewNote = false;
+						Note* createdNewNote = nullptr;
 						// did we click on a note or are we creating new?
 						if (n == nullptr) // create new note at mouse click position
 						{
-							is_new_note = true;
+							isNewNote = true;
 							m_pattern->addJournalCheckPoint();
 							// clear selection and select this new note
 							clearSelectedNotes();
 							// +32 to quanitize the note correctly when placing notes with
 							// the mouse.  We do this here instead of in note.quantized
 							// because live notes should still be quantized at the half.
-							TimePos note_pos(pos_ticks - (quantization() / 2));
-							TimePos note_len(newNoteLen());
+							TimePos notePos(posTicks - (quantization() / 2));
+							TimePos noteLen(newNoteLen());
 
 							// create new note and add to pattern
-							Note new_note(note_len, note_pos, key_num);
-							new_note.setSelected(true);
-							new_note.setPanning(m_lastNotePanning);
-							new_note.setVolume(m_lastNoteVolume);
-							created_new_note = m_pattern->addNote(new_note);
+							Note newNote(noteLen, notePos, keyNum);
+							newNote.setSelected(true);
+							newNote.setPanning(m_lastNotePanning);
+							newNote.setVolume(m_lastNoteVolume);
+							createdNewNote = m_pattern->addNote(newNote);
 
 							// check for chord draw
 							const InstrumentFunctionNoteStacking::Chord & chord =
@@ -1746,17 +1746,17 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 								{
 									if (m_startedWithShift) // arpeggio mode
 									{
-										note_pos += note_len;
+										notePos += noteLen;
 									}
-									Note new_note(note_len, note_pos, key_num + chord[i]);
-									new_note.setSelected(true);
-									new_note.setPanning(m_lastNotePanning);
-									new_note.setVolume(m_lastNoteVolume);
-									m_pattern->addNote(new_note);
+									Note newNote(noteLen, notePos, keyNum + chord[i]);
+									newNote.setSelected(true);
+									newNote.setPanning(m_lastNotePanning);
+									newNote.setVolume(m_lastNoteVolume);
+									m_pattern->addNote(newNote);
 								}
 							}
 
-							m_currentNote = created_new_note;
+							m_currentNote = createdNewNote;
 							m_lastNotePanning = m_currentNote->getPanning();
 							m_lastNoteVolume = m_currentNote->getVolume();
 							m_lenOfNewNotes = m_currentNote->length();
@@ -1767,7 +1767,8 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 						m_mouseDownKey = m_startKey;
 						m_mouseDownTick = m_currentPosition;
 
-						// check if m_currentNote is still selected
+						// Check if m_currentNote is selected
+						// If user clicked in an unselected note it won't be
 						if (!m_currentNote->selected())
 						{
 							// clear notes and select this note
@@ -1775,7 +1776,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 							m_currentNote->setSelected(true);
 						}
 
-						// if we didn't click on a note or we did, get new bounding box
+						// Get new bounding box for the current selection
 						auto selectedNotes = getSelectedNotes();
 						m_moveBoundaryLeft = selectedNotes.first()->pos().getTicks();
 						m_moveBoundaryRight = selectedNotes.first()->endPos();
@@ -1794,7 +1795,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 						}
 						printf("check tail\n");
 						// clicked at the "tail" of the note?
-						if( pos_ticks * m_ppb / TimePos::ticksPerBar() >
+						if( posTicks * m_ppb / TimePos::ticksPerBar() >
 								m_currentNote->endPos() * m_ppb / TimePos::ticksPerBar() - RESIZE_AREA_WIDTH
 							&& m_currentNote->length() > 0 )
 						{
@@ -1830,7 +1831,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 						}
 						else
 						{
-							if( ! created_new_note )
+							if( ! createdNewNote )
 							{
 								m_pattern->addJournalCheckPoint();
 							}
@@ -1842,7 +1843,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 							setCursor( Qt::SizeAllCursor );
 
 							// if they're holding shift, copy all selected notes
-							if( ! is_new_note && me->modifiers() & Qt::ShiftModifier )
+							if( ! isNewNote && me->modifiers() & Qt::ShiftModifier )
 							{
 								for (Note *note: selectedNotes)
 								{
@@ -1895,9 +1896,9 @@ void PianoRoll::mousePressEvent(QMouseEvent * me)
 				{
 					if (leftButton) // select an area of notes
 					{
-						m_selectStartTick = pos_ticks;
+						m_selectStartTick = posTicks;
 						m_selectedTick = 0;
-						m_selectStartKey = key_num;
+						m_selectStartKey = keyNum;
 						m_selectedKeys = 1;
 						m_action = ActionSelectNotes;
 						printf("start ModeSelect\n");


### PR DESCRIPTION
Adds a action to remove notes on the PianoRoll and remove an unnecessary member variable that was only being used to handle that action (m_mouseDownRight).

Also removes unnecessary handling of the play key action on the ActionNone case switch from the mouseMoveEvent. Adds a update() call on the ActionPlayKeys (so it updates the cursor) and a break; statement for consistency. Fixes the calculation of the velocity.
