### PR TITLE
Ticks, selection, noteEditHeight refactoring

### DIFF
--- a/src/gui/TimeLineWidget.cpp
+++ b/src/gui/TimeLineWidget.cpp
@@ -310,7 +310,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 	{
 		return;
 	}
-	if( event->button() == Qt::LeftButton  && !(event->modifiers() & Qt::ShiftModifier) )
+	if (event->button() == Qt::LeftButton && !(event->modifiers() & Qt::ControlModifier))
 	{
 		m_action = MovePositionMarker;
 		if( event->x() - m_xOffset < s_posMarkerPixmap->width() )
@@ -322,7 +322,7 @@ void TimeLineWidget::mousePressEvent( QMouseEvent* event )
 			m_moveXOff = s_posMarkerPixmap->width() / 2;
 		}
 	}
-	else if( event->button() == Qt::LeftButton  && (event->modifiers() & Qt::ShiftModifier) )
+	else if (event->button() == Qt::LeftButton && (event->modifiers() & Qt::ControlModifier))
 	{
 		m_action = SelectSongTCO;
 		m_initalXSelect = event->x();


### PR DESCRIPTION
AAAaaah I'm so sorry! I was working on *one* thing and the next minute I've got a patch the size of a truck.

The main purpose of this PR is simplifying code. But because PianoRoll is *sooo full of bugs* this has lead to lot of fixes as well. There are definitely things that may be split out as their own PR, but they rely on code introduced in this PR. Well, maybe you and @IanCaio can help straighten this out.

I'll try to make a summary. Here goes...

## Simplifying things

### Re-use mouse position
By creating functions for common calculations, and by saving mouse hover position and mouse press down position, we can save a lot of work later.

- getTick(), xCoordOfTick(), yCoordOfKey()
- m_hoverTick, m_hoverKey
- m_mouseDownTick, m_mouseDownKey (store click pos instead of view pos)
- PianoRollArea::Margin
- m_ctrlPressed, m_shiftPressed, m_altPressed

### Fix note edit resizing
Remove dirty code from paintEvent and make a function that only scales the note edit area in qunatized steps. This fixes visual glitches when resizing.

### Clean up paintEvent
Ok so this part is a bit off topic... Use common functions where possible. Remove some obscure switch statements. Move (tons of) repeated code to drawNoteRect.

### Other simplifications
- Ctrl+A selects instantly instead of drawing a rectangle.
- m_ctrlMode and m_knifeMode replaced by m_lastEditMode.
- Do int division the right way instead of casting from int to float to int (tell me if I'm stupid).

## Fixing things

- Do note begin a new drag action when another mouse button is already pressed.
- Do not allow Ctrl+Shift+A or things like that when a drag action is active.
- Do not resize drum notes during shift-drag.
- Allow dragging outside note edit area to create 200% or 0% velocity.
- Bounding box didn't update when clicked on selected note.
- Correct key when dragging notes below the bottom line.
- L1900 shift-drag broken by wrong operator.
- L1961 selection at wrong spot on mouse down - may be fixed...?
- Double click on note edit handle edits all notes at same position.
- Re-calculate note position on scroll.
- Scrolling on note edit handle while holding alt should not change unselected notes.
- Do not play unselected notes when dragging in the note edit area.
- Fix sound glitch when dragging a group of notes against the top or bottom of editor.
- Exclude scrollbar from noteEditRight()
- Silence everything on foucsOutEvent.

## Because I say so... things

### Test play selected stack
Instead of playing selected (in dropdown) chord when clicking the note editor, we play the selected notes on that tick. This fixes a bug when editing velocity of multiple notes while in chord mode. Relates to changes in focusOutEvent().

### Timeline selection
**Timeline drag-to-select modifier key changed from shift to control.** This is my personal opinion. Also, now a rectangle is drawn on mouse down and the selection happens on mouse release.

### Other UX changes
- Restore notes to their initial position if drag action is interrupted by focusOut or Esc.
- Do not move notes in select mode. It becomes impossible to click select notes! Sorry.
- Do not knife cut with right button. It is used to exit. Don't confuse me.

----

If you find it overwhelming (I do), just lean back with a cup of coffee and look at all those wonderful red lines in the diff :)