### PR TITLE
Removing more QVector from core

### DIFF
--- a/include/AudioEngine.h
+++ b/include/AudioEngine.h
@@ -27,10 +27,10 @@
 
 #include <QMutex>
 #include <QThread>
-#include <QVector>
 #include <QWaitCondition>
 #include <samplerate.h>
 
+#include <vector>
 
 #include "lmms_basics.h"
 #include "LocklessList.h"
@@ -366,7 +366,7 @@ private:
 
 	bool m_renderOnly;
 
-	QVector<AudioPort *> m_audioPorts;
+	std::vector<AudioPort *> m_audioPorts;
 
 	fpp_t m_framesPerPeriod;
 
@@ -380,7 +380,7 @@ private:
 	surroundSampleFrame * m_outputBufferWrite;
 
 	// worker thread stuff
-	QVector<AudioEngineWorkerThread *> m_workers;
+	std::vector<AudioEngineWorkerThread *> m_workers;
 	int m_numWorkers;
 
 	// playhandle stuff

--- a/include/AudioEngineWorkerThread.h
+++ b/include/AudioEngineWorkerThread.h
@@ -96,7 +96,7 @@ public:
 							JobQueue::OperationMode _opMode = JobQueue::Static )
 	{
 		resetJobQueue( _opMode );
-		for( typename T::ConstIterator it = _vec.begin(); it != _vec.end(); ++it )
+		for (typename T::const_iterator it = _vec.begin(); it != _vec.end(); ++it)
 		{
 			addJob( *it );
 		}

--- a/include/AudioJack.h
+++ b/include/AudioJack.h
@@ -35,7 +35,7 @@
 #endif
 
 #include <atomic>
-#include <QVector>
+#include <vector>
 
 #include "AudioDevice.h"
 #include "AudioDeviceSetupWidget.h"
@@ -109,7 +109,7 @@ private:
 	std::atomic<bool> m_stopped;
 
 	std::atomic<MidiJack *> m_midiClient;
-	QVector<jack_port_t *> m_outputPorts;
+	std::vector<jack_port_t*> m_outputPorts;
 	jack_default_audio_sample_t * * m_tempOutBufs;
 	surroundSampleFrame * m_outBuf;
 

--- a/include/AutomatableModel.h
+++ b/include/AutomatableModel.h
@@ -25,6 +25,8 @@
 #ifndef AUTOMATABLE_MODEL_H
 #define AUTOMATABLE_MODEL_H
 
+#include <vector>
+
 #include <QMap>
 #include <QMutex>
 
@@ -75,7 +77,7 @@ class LMMS_EXPORT AutomatableModel : public Model, public JournallingObject
 	MM_OPERATORS
 public:
 
-	typedef QVector<AutomatableModel *> AutoModelVector;
+	using AutoModelVector = std::vector<AutomatableModel*>;
 
 	enum ScaleType
 	{

--- a/include/AutomationClip.h
+++ b/include/AutomationClip.h
@@ -30,6 +30,8 @@
 #include <QMap>
 #include <QPointer>
 
+#include <vector>
+
 #include "AutomationNode.h"
 #include "Clip.h"
 
@@ -51,7 +53,7 @@ public:
 	} ;
 
 	typedef QMap<int, AutomationNode> timeMap;
-	typedef QVector<QPointer<AutomatableModel>> objectVector;
+	using objectVector = std::vector<QPointer<AutomatableModel>>;
 
 	using TimemapIterator = timeMap::const_iterator;
 
@@ -156,7 +158,7 @@ public:
 
 
 	static bool isAutomated( const AutomatableModel * _m );
-	static QVector<AutomationClip *> clipsForModel( const AutomatableModel * _m );
+	static std::vector<AutomationClip *> clipsForModel(const AutomatableModel * _m);
 	static AutomationClip * globalAutomationClip( AutomatableModel * _m );
 	static void resolveAllIDs();
 
@@ -184,7 +186,7 @@ private:
 	mutable QMutex m_clipMutex;
 
 	AutomationTrack * m_autoTrack;
-	QVector<jo_id_t> m_idsToResolve;
+	std::vector<jo_id_t> m_idsToResolve;
 	objectVector m_objects;
 	timeMap m_timeMap;	// actual values
 	timeMap m_oldTimeMap;	// old values for storing the values before setDragValue() is called.

--- a/include/ConfigManager.h
+++ b/include/ConfigManager.h
@@ -26,12 +26,13 @@
 #ifndef CONFIG_MGR_H
 #define CONFIG_MGR_H
 
+#include <vector>
+
 #include "lmmsconfig.h"
 
 #include <QMap>
 #include <QPair>
 #include <QStringList>
-#include <QVector>
 #include <QObject>
 
 #include "lmms_export.h"
@@ -236,8 +237,8 @@ public:
 
 	void addRecentlyOpenedProject(const QString & _file);
 
-	const QString & value(const QString & cls,
-					const QString & attribute) const;
+	const QString value(const QString& cls, const QString& attribute) const;
+
 	const QString & value(const QString & cls,
 					const QString & attribute,
 					const QString & defaultVal) const;
@@ -299,7 +300,7 @@ private:
 	unsigned int m_configVersion;
 	QStringList m_recentlyOpenedProjects;
 
-	typedef QVector<QPair<QString, QString> > stringPairVector;
+	using stringPairVector = std::vector<QPair<QString, QString>>;
 	typedef QMap<QString, stringPairVector> settingsMap;
 	settingsMap m_settings;
 

--- a/include/Controller.h
+++ b/include/Controller.h
@@ -27,6 +27,8 @@
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
 
+#include <vector>
+
 #include "lmms_export.h"
 #include "Engine.h"
 #include "Model.h"
@@ -37,7 +39,7 @@ class ControllerDialog;
 class Controller;
 class ControllerConnection;
 
-typedef QVector<Controller *> ControllerVector;
+using ControllerVector = std::vector<Controller*>;
 
 
 class LMMS_EXPORT Controller : public Model, public JournallingObject

--- a/include/ControllerConnection.h
+++ b/include/ControllerConnection.h
@@ -30,8 +30,9 @@
 #ifndef CONTROLLER_CONNECTION_H
 #define CONTROLLER_CONNECTION_H
 
+#include <vector>
+
 #include <QObject>
-#include <QVector>
 
 #include "Controller.h"
 #include "JournallingObject.h"
@@ -39,7 +40,7 @@
 
 class ControllerConnection;
 
-typedef QVector<ControllerConnection *> ControllerConnectionVector;
+using ControllerConnectionVector = std::vector<ControllerConnection*>;
 
 
 class LMMS_EXPORT ControllerConnection : public QObject, public JournallingObject

--- a/include/EffectChain.h
+++ b/include/EffectChain.h
@@ -59,7 +59,7 @@ public:
 
 
 private:
-	typedef QVector<Effect *> EffectList;
+	using EffectList = std::vector<Effect*>;
 	EffectList m_effects;
 
 	BoolModel m_enabledModel;

--- a/include/EnvelopeAndLfoParameters.h
+++ b/include/EnvelopeAndLfoParameters.h
@@ -25,8 +25,6 @@
 #ifndef ENVELOPE_AND_LFO_PARAMETERS_H
 #define ENVELOPE_AND_LFO_PARAMETERS_H
 
-#include <QVector>
-
 #include "JournallingObject.h"
 #include "AutomatableModel.h"
 #include "SampleBuffer.h"

--- a/include/InstrumentFunctions.h
+++ b/include/InstrumentFunctions.h
@@ -108,38 +108,43 @@ public:
 		}
 	};
 
-
-	struct ChordTable : public QVector<Chord>
+	class ChordTable 
 	{
-	private:
-		ChordTable();
-
-		struct Init
-		{
-			const char * m_name;
-			ChordSemiTones m_semiTones;
-		};
-
-		static Init s_initTable[];
-
 	public:
-		static const ChordTable & getInstance()
+		static const ChordTable& getInstance() 
 		{
 			static ChordTable inst;
 			return inst;
 		}
 
-		const Chord & getByName( const QString & name, bool is_scale = false ) const;
+		const Chord& getByName(const QString& name, bool is_scale = false) const;
 
-		const Chord & getScaleByName( const QString & name ) const
+		const Chord& getScaleByName(const QString& name) const
 		{
-			return getByName( name, true );
+			return getByName(name, true);
 		}
 
-		const Chord & getChordByName( const QString & name ) const
+		const Chord& getChordByName(const QString& name) const
 		{
-			return getByName( name, false );
+			return getByName(name, false);
 		}
+
+		const std::vector<Chord>& chords() const 
+		{
+			return m_chords;
+		}
+	private:
+		ChordTable();
+
+		struct Init 
+		{
+			const char* m_name;
+			ChordSemiTones m_semiTones;
+		};
+
+		static Init s_initTable[];
+
+		std::vector<Chord> m_chords;
 	};
 
 

--- a/include/MidiClient.h
+++ b/include/MidiClient.h
@@ -25,9 +25,8 @@
 #ifndef MIDI_CLIENT_H
 #define MIDI_CLIENT_H
 
+#include <vector>
 #include <QStringList>
-#include <QVector>
-
 
 #include "MidiEvent.h"
 
@@ -107,7 +106,7 @@ public:
 	static MidiClient * openMidiClient();
 
 protected:
-	QVector<MidiPort *> m_midiPorts;
+	std::vector<MidiPort*> m_midiPorts;
 
 } ;
 

--- a/include/Mixer.h
+++ b/include/Mixer.h
@@ -35,7 +35,7 @@
 #include <QColor>
 
 class MixerRoute;
-typedef QVector<MixerRoute *> MixerRouteVector;
+using MixerRouteVector = std::vector<MixerRoute*>;
 
 class MixerChannel : public ThreadableJob
 {
@@ -211,7 +211,7 @@ public:
 
 private:
 	// the mixer channels in the mixer. index 0 is always master.
-	QVector<MixerChannel *> m_mixerChannels;
+	std::vector<MixerChannel*> m_mixerChannels;
 
 	// make sure we have at least num channels
 	void allocateChannelsTo(int num);

--- a/include/Note.h
+++ b/include/Note.h
@@ -26,7 +26,7 @@
 #ifndef NOTE_H
 #define NOTE_H
 
-#include <QVector>
+#include <vector>
 
 #include "volume.h"
 #include "panning.h"
@@ -244,7 +244,7 @@ private:
 };
 
 
-typedef QVector<Note *> NoteVector;
+using NoteVector = std::vector<Note*>;
 
 
 #endif

--- a/include/PeakController.h
+++ b/include/PeakController.h
@@ -32,7 +32,7 @@ class QWidget;
 
 class PeakControllerEffect;
 
-typedef QVector<PeakControllerEffect *> PeakControllerEffectVector;
+using PeakControllerEffectVector = std::vector<PeakControllerEffect*>;
 
 
 class LMMS_EXPORT PeakController : public Controller

--- a/include/PluginFactory.h
+++ b/include/PluginFactory.h
@@ -27,11 +27,11 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <QFileInfo>
 #include <QList>
 #include <QString>
-#include <QVector>
 
 #include "lmms_export.h"
 #include "Plugin.h"
@@ -95,7 +95,7 @@ private:
 	PluginInfoList m_pluginInfos;
 
 	QMap<QString, PluginInfoAndKey> m_pluginByExt;
-	QVector<std::string> m_garbage; //!< cleaned up at destruction
+	std::vector<std::string> m_garbage; //!< cleaned up at destruction
 
 	QHash<QString, QString> m_errors;
 

--- a/include/RenderManager.h
+++ b/include/RenderManager.h
@@ -27,6 +27,7 @@
 #define RENDER_MANAGER_H
 
 #include <memory>
+#include <vector>
 
 #include "ProjectRenderer.h"
 #include "OutputSettings.h"
@@ -74,8 +75,8 @@ private:
 
 	std::unique_ptr<ProjectRenderer> m_activeRenderer;
 
-	QVector<Track*> m_tracksToRender;
-	QVector<Track*> m_unmuted;
+	std::vector<Track*> m_tracksToRender;
+	std::vector<Track*> m_unmuted;
 } ;
 
 #endif

--- a/include/StepRecorder.h
+++ b/include/StepRecorder.h
@@ -26,6 +26,8 @@
 #include <QTimer>
 #include <QObject>
 
+#include <vector>
+
 #include "Note.h"
 
 class MidiClip;
@@ -51,7 +53,7 @@ class StepRecorder : public QObject
 	void setCurrentMidiClip(MidiClip* newMidiClip);
 	void setStepsLength(const TimePos& newLength);
 
-	QVector<Note*> getCurStepNotes();
+	std::vector<Note*> getCurStepNotes();
 
 	bool isRecording() const
 	{
@@ -134,7 +136,7 @@ class StepRecorder : public QObject
 		QElapsedTimer releasedTimer;
 	} ;
 
-	QVector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the clip)
+	std::vector<StepNote*> m_curStepNotes; // contains the current recorded step notes (i.e. while user still press the notes; before they are applied to the clip)
 
 	StepNote* findCurStepNote(const int key);
 

--- a/include/Track.h
+++ b/include/Track.h
@@ -26,7 +26,6 @@
 #define TRACK_H
 
 
-#include <QVector>
 #include <QColor>
 
 #include "AutomatableModel.h"
@@ -60,7 +59,7 @@ class LMMS_EXPORT Track : public Model, public JournallingObject
 	mapPropertyFromModel(bool,isMuted,setMuted,m_mutedModel);
 	mapPropertyFromModel(bool,isSolo,setSolo,m_soloModel);
 public:
-	typedef QVector<Clip *> clipVector;
+	using clipVector = std::vector<Clip*>;
 
 	enum TrackTypes
 	{

--- a/include/TrackContainer.h
+++ b/include/TrackContainer.h
@@ -41,7 +41,7 @@ class LMMS_EXPORT TrackContainer : public Model, public JournallingObject
 {
 	Q_OBJECT
 public:
-	typedef QVector<Track *> TrackList;
+	using TrackList = std::vector<Track *>;
 	enum TrackContainerTypes
 	{
 		PatternContainer,

--- a/include/panning.h
+++ b/include/panning.h
@@ -26,6 +26,8 @@
 #ifndef PANNING_H
 #define PANNING_H
 
+#include <cmath>
+
 #include "lmms_basics.h"
 #include "panning_constants.h"
 #include "Midi.h"
@@ -36,7 +38,7 @@ inline StereoVolumeVector panningToVolumeVector( panning_t _p,
 {
 	StereoVolumeVector v = { { _scale, _scale } };
 	const float pf = _p / 100.0f;
-	v.vol[_p >= PanningCenter ? 0 : 1] *= 1.0f - qAbs<float>( pf );
+	v.vol[_p >= PanningCenter ? 0 : 1] *= 1.0f - std::abs(pf);
 	return v;
 }
 

--- a/plugins/PeakControllerEffect/PeakControllerEffect.cpp
+++ b/plugins/PeakControllerEffect/PeakControllerEffect.cpp
@@ -72,7 +72,7 @@ PeakControllerEffect::PeakControllerEffect(
 	{
 		Engine::getSong()->addController( m_autoController );
 	}
-	PeakController::s_effects.append( this );
+	PeakController::s_effects.push_back(this);
 }
 
 
@@ -80,11 +80,11 @@ PeakControllerEffect::PeakControllerEffect(
 
 PeakControllerEffect::~PeakControllerEffect()
 {
-	int idx = PeakController::s_effects.indexOf( this );
-	if( idx >= 0 )
+	auto it = std::find(PeakController::s_effects.begin(), PeakController::s_effects.end(), this);
+	if (it != PeakController::s_effects.end())
 	{
-		PeakController::s_effects.remove( idx );
-		Engine::getSong()->removeController( m_autoController );
+		PeakController::s_effects.erase(it);
+		Engine::getSong()->removeController(m_autoController);
 	}
 }
 

--- a/src/core/AudioEngine.cpp
+++ b/src/core/AudioEngine.cpp
@@ -415,7 +415,7 @@ const surroundSampleFrame * AudioEngine::renderNextBuffer()
 	}
 
 	// STAGE 2: process effects of all instrument- and sampletracks
-	AudioEngineWorkerThread::fillJobQueue<QVector<AudioPort *> >( m_audioPorts );
+	AudioEngineWorkerThread::fillJobQueue<std::vector<AudioPort *> >(m_audioPorts);
 	AudioEngineWorkerThread::startAndWaitForJobs();
 
 
@@ -659,7 +659,7 @@ void AudioEngine::removeAudioPort(AudioPort * port)
 {
 	requestChangeInModel();
 
-	QVector<AudioPort *>::Iterator it = std::find(m_audioPorts.begin(), m_audioPorts.end(), port);
+	auto it = std::find(m_audioPorts.begin(), m_audioPorts.end(), port);
 	if (it != m_audioPorts.end())
 	{
 		m_audioPorts.erase(it);

--- a/src/core/AutomatableModel.cpp
+++ b/src/core/AutomatableModel.cpp
@@ -68,7 +68,7 @@ AutomatableModel::~AutomatableModel()
 {
 	while( m_linkedModels.empty() == false )
 	{
-		m_linkedModels.last()->unlinkModel( this );
+		m_linkedModels.back()->unlinkModel(this);
 		m_linkedModels.erase( m_linkedModels.end() - 1 );
 	}
 
@@ -302,7 +302,7 @@ void AutomatableModel::setValue( const float value )
 		addJournalCheckPoint();
 
 		// notify linked models
-		for( AutoModelVector::Iterator it = m_linkedModels.begin(); it != m_linkedModels.end(); ++it )
+		for (auto it = m_linkedModels.begin(); it != m_linkedModels.end(); ++it)
 		{
 			if( (*it)->m_setValueDepth < 1 && (*it)->fittedValue( value ) != (*it)->m_value )
 			{
@@ -385,8 +385,7 @@ void AutomatableModel::setAutomatedValue( const float value )
 	if( oldValue != m_value )
 	{
 		// notify linked models
-		for (AutoModelVector::Iterator it = m_linkedModels.begin();
-			it != m_linkedModels.end(); ++it)
+		for (auto it = m_linkedModels.begin(); it != m_linkedModels.end(); ++it)
 		{
 			if (!((*it)->controllerConnection()) && (*it)->m_setValueDepth < 1 &&
 					(*it)->fittedValue(m_value) != (*it)->m_value)
@@ -471,7 +470,7 @@ float AutomatableModel::fittedValue( float value ) const
 
 void AutomatableModel::linkModel( AutomatableModel* model )
 {
-	if( !m_linkedModels.contains( model ) && model != this )
+	if (std::find(m_linkedModels.begin(), m_linkedModels.end(), model) == m_linkedModels.end() && model != this)
 	{
 		m_linkedModels.push_back( model );
 
@@ -488,10 +487,10 @@ void AutomatableModel::linkModel( AutomatableModel* model )
 
 void AutomatableModel::unlinkModel( AutomatableModel* model )
 {
-	AutoModelVector::Iterator it = std::find( m_linkedModels.begin(), m_linkedModels.end(), model );
-	if( it != m_linkedModels.end() )
+	auto it = std::find(m_linkedModels.begin(), m_linkedModels.end(), model);
+	if (it != m_linkedModels.end())
 	{
-		m_linkedModels.erase( it );
+		m_linkedModels.erase(it);
 	}
 }
 
@@ -502,7 +501,7 @@ void AutomatableModel::unlinkModel( AutomatableModel* model )
 
 void AutomatableModel::linkModels( AutomatableModel* model1, AutomatableModel* model2 )
 {
-	if (!model1->m_linkedModels.contains( model2 ) && model1 != model2)
+	if (std::find(model1->m_linkedModels.begin(), model1->m_linkedModels.end(), model2) == model1->m_linkedModels.end() && model1 != model2)
 	{
 		// copy data
 		model1->m_value = model2->m_value;
@@ -586,7 +585,7 @@ float AutomatableModel::controllerValue( int frameOffset ) const
 		return v;
 	}
 
-	AutomatableModel* lm = m_linkedModels.first();
+	AutomatableModel* lm = m_linkedModels.front();
 	if (lm->controllerConnection() && lm->useControllerValue())
 	{
 		return fittedValue( lm->controllerValue( frameOffset ) );
@@ -647,7 +646,7 @@ ValueBuffer * AutomatableModel::valueBuffer()
 		AutomatableModel* lm = nullptr;
 		if (hasLinkedModels())
 		{
-			lm = m_linkedModels.first();
+			lm = m_linkedModels.front();
 		}
 		if (lm && lm->controllerConnection() && lm->useControllerValue() &&
 				lm->controllerConnection()->getController()->isSampleExact())
@@ -719,8 +718,8 @@ void AutomatableModel::reset()
 float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 {
 	// get clips that connect to this model
-	QVector<AutomationClip *> clips = AutomationClip::clipsForModel( this );
-	if( clips.isEmpty() )
+	std::vector<AutomationClip *> clips = AutomationClip::clipsForModel(this);
+	if (clips.empty())
 	{
 		// if no such clips exist, return current value
 		return m_value;
@@ -729,17 +728,17 @@ float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 	{
 		// of those clips:
 		// find the clips which overlap with the time position
-		QVector<AutomationClip *> clipsInRange;
-		for( QVector<AutomationClip *>::ConstIterator it = clips.begin(); it != clips.end(); it++ )
+		std::vector<AutomationClip *> clipsInRange;
+		for (std::vector<AutomationClip *>::const_iterator it = clips.begin(); it != clips.end(); it++)
 		{
 			int s = ( *it )->startPosition();
 			int e = ( *it )->endPosition();
-			if( s <= time && e >= time ) { clipsInRange += ( *it ); }
+			if (s <= time && e >= time) { clipsInRange.push_back(*it); }
 		}
 
 		AutomationClip * latestClip = nullptr;
 
-		if( ! clipsInRange.isEmpty() )
+		if (!clipsInRange.empty())
 		{
 			// if there are more than one overlapping clips, just use the first one because
 			// multiple clip behaviour is undefined anyway
@@ -750,7 +749,7 @@ float AutomatableModel::globalAutomationValueAt( const TimePos& time )
 		{
 			int latestPosition = 0;
 
-			for( QVector<AutomationClip *>::ConstIterator it = clips.begin(); it != clips.end(); it++ )
+			for (std::vector<AutomationClip *>::const_iterator it = clips.begin(); it != clips.end(); it++)
 			{
 				int e = ( *it )->endPosition();
 				if( e <= time && e > latestPosition )

--- a/src/core/AutomationClip.cpp
+++ b/src/core/AutomationClip.cpp
@@ -113,19 +113,19 @@ bool AutomationClip::addObject( AutomatableModel * _obj, bool _search_dup )
 {
 	QMutexLocker m(&m_clipMutex);
 
-	if( _search_dup && m_objects.contains(_obj) )
+	if (_search_dup && std::find(m_objects.begin(), m_objects.end(), _obj) != m_objects.end())
 	{
 		return false;
 	}
 
 	// the automation track is unconnected and there is nothing in the track
-	if( m_objects.isEmpty() && hasAutomation() == false )
+	if (m_objects.empty() && hasAutomation() == false)
 	{
 		// then initialize first value
 		putValue( TimePos(0), _obj->inverseScaledValue( _obj->value<float>() ), false );
 	}
 
-	m_objects += _obj;
+	m_objects.push_back(_obj);
 
 	connect( _obj, SIGNAL( destroyed( jo_id_t ) ),
 			this, SLOT( objectDestroyed( jo_id_t ) ),
@@ -177,7 +177,7 @@ const AutomatableModel * AutomationClip::firstObject() const
 	QMutexLocker m(&m_clipMutex);
 
 	AutomatableModel* model;
-	if (!m_objects.isEmpty() && (model = m_objects.first()) != nullptr)
+	if (!m_objects.empty() && (model = *(m_objects.begin())) != nullptr)
 	{
 		return model;
 	}
@@ -373,11 +373,11 @@ void AutomationClip::removeNodes(const int tick0, const int tick1)
 	// Make a list of TimePos with nodes to be removed
 	// because we can't simply remove the nodes from
 	// the timeMap while we are iterating it.
-	QVector<TimePos> nodesToRemove;
+	std::vector<TimePos> nodesToRemove;
 
 	for (auto it = m_timeMap.lowerBound(start), endIt = m_timeMap.upperBound(end); it != endIt; ++it)
 	{
-		nodesToRemove.append(POS(it));
+		nodesToRemove.push_back(POS(it));
 	}
 
 	for (auto node: nodesToRemove)
@@ -826,7 +826,7 @@ void AutomationClip::loadSettings( const QDomElement & _this )
 		}
 		else if( element.tagName() == "object" )
 		{
-			m_idsToResolve << element.attribute( "id" ).toInt();
+			m_idsToResolve.push_back(element.attribute( "id" ).toInt());
 		}
 	}
 	
@@ -860,9 +860,9 @@ const QString AutomationClip::name() const
 	{
 		return Clip::name();
 	}
-	if( !m_objects.isEmpty() && m_objects.first() != nullptr )
+	if (!m_objects.empty() && m_objects.begin() != m_objects.end())
 	{
-		return m_objects.first()->fullDisplayName();
+		return m_objects.begin()->data()->fullDisplayName();
 	}
 	return tr( "Drag a control while pressing <%1>" ).arg(UI_CTRL_KEY);
 }
@@ -884,17 +884,22 @@ ClipView * AutomationClip::createView( TrackView * _tv )
 bool AutomationClip::isAutomated( const AutomatableModel * _m )
 {
 	TrackContainer::TrackList l;
-	l += Engine::getSong()->tracks();
-	l += Engine::patternStore()->tracks();
-	l += Engine::getSong()->globalAutomationTrack();
+	
+	auto& songTracks = Engine::getSong()->tracks();
+	l.insert(l.end(), songTracks.begin(), songTracks.end());
 
-	for( TrackContainer::TrackList::ConstIterator it = l.begin(); it != l.end(); ++it )
+	auto& patternStoreTracks = Engine::patternStore()->tracks();
+	l.insert(l.end(), patternStoreTracks.begin(), patternStoreTracks.end());
+
+	l.push_back(Engine::getSong()->globalAutomationTrack());
+
+	for (auto it = l.begin(); it != l.end(); ++it)
 	{
 		if( ( *it )->type() == Track::AutomationTrack ||
 			( *it )->type() == Track::HiddenAutomationTrack )
 		{
 			const Track::clipVector & v = ( *it )->getClips();
-			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
+			for (auto j = v.begin(); j != v.end(); ++j)
 			{
 				const AutomationClip * a = dynamic_cast<const AutomationClip *>( *j );
 				if( a && a->hasAutomation() )
@@ -918,16 +923,21 @@ bool AutomationClip::isAutomated( const AutomatableModel * _m )
  * @brief returns a list of all the automation clips that are connected to a specific model
  * @param _m the model we want to look for
  */
-QVector<AutomationClip *> AutomationClip::clipsForModel( const AutomatableModel * _m )
+std::vector<AutomationClip *> AutomationClip::clipsForModel(const AutomatableModel * _m)
 {
-	QVector<AutomationClip *> clips;
+	std::vector<AutomationClip *> clips;
 	TrackContainer::TrackList l;
-	l += Engine::getSong()->tracks();
-	l += Engine::patternStore()->tracks();
-	l += Engine::getSong()->globalAutomationTrack();
 
+	auto& songTracks = Engine::getSong()->tracks();
+	l.insert(l.end(), songTracks.begin(), songTracks.end());
+
+	auto& patternStoreTracks = Engine::patternStore()->tracks();
+	l.insert(l.end(), patternStoreTracks.begin(), patternStoreTracks.end());
+
+	l.push_back(Engine::getSong()->globalAutomationTrack());
+	
 	// go through all tracks...
-	for( TrackContainer::TrackList::ConstIterator it = l.begin(); it != l.end(); ++it )
+	for (auto it = l.begin(); it != l.end(); ++it)
 	{
 		// we want only automation tracks...
 		if( ( *it )->type() == Track::AutomationTrack ||
@@ -936,7 +946,7 @@ QVector<AutomationClip *> AutomationClip::clipsForModel( const AutomatableModel 
 			// get clips in those tracks....
 			const Track::clipVector & v = ( *it )->getClips();
 			// go through all the clips...
-			for( Track::clipVector::ConstIterator j = v.begin(); j != v.end(); ++j )
+			for (auto j = v.begin(); j != v.end(); ++j)
 			{
 				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
 				// check that the clip has automation
@@ -953,7 +963,7 @@ QVector<AutomationClip *> AutomationClip::clipsForModel( const AutomatableModel 
 						}
 					}
 					// if the clips is connected to the model, add it to the list
-					if( has_object ) { clips += a; }
+					if (has_object) { clips.push_back(a); }
 				}
 			}
 		}
@@ -994,9 +1004,13 @@ AutomationClip * AutomationClip::globalAutomationClip(
 
 void AutomationClip::resolveAllIDs()
 {
-	TrackContainer::TrackList l = Engine::getSong()->tracks() +
-				Engine::patternStore()->tracks();
-	l += Engine::getSong()->globalAutomationTrack();
+	TrackContainer::TrackList l = Engine::getSong()->tracks();
+
+	auto& patternStoreTracks = Engine::patternStore()->tracks();
+	l.insert(l.begin(), patternStoreTracks.begin(), patternStoreTracks.end());
+	
+	l.push_back(Engine::getSong()->globalAutomationTrack());
+
 	for( TrackContainer::TrackList::iterator it = l.begin();
 							it != l.end(); ++it )
 	{
@@ -1010,7 +1024,7 @@ void AutomationClip::resolveAllIDs()
 				AutomationClip * a = dynamic_cast<AutomationClip *>( *j );
 				if( a )
 				{
-					for( QVector<jo_id_t>::Iterator k = a->m_idsToResolve.begin();
+					for (std::vector<jo_id_t>::iterator k = a->m_idsToResolve.begin();
 									k != a->m_idsToResolve.end(); ++k )
 					{
 						JournallingObject * o = Engine::projectJournal()->
@@ -1071,9 +1085,9 @@ void AutomationClip::objectDestroyed( jo_id_t _id )
 	// when switching samplerate) and real deletions because in the latter
 	// case we had to remove ourselves if we're the global automation
 	// clip of the destroyed object
-	m_idsToResolve += _id;
+	m_idsToResolve.push_back(_id);
 
-	for( objectVector::Iterator objIt = m_objects.begin();
+	for (objectVector::iterator objIt = m_objects.begin();
 		objIt != m_objects.end(); objIt++ )
 	{
 		Q_ASSERT( !(*objIt).isNull() );

--- a/src/core/ConfigManager.cpp
+++ b/src/core/ConfigManager.cpp
@@ -331,23 +331,20 @@ void ConfigManager::addRecentlyOpenedProject(const QString & file)
 
 
 
-const QString & ConfigManager::value(const QString & cls,
+const QString ConfigManager::value(const QString & cls,
 					const QString & attribute) const
 {
-	if(m_settings.contains(cls))
+	if (m_settings.contains(cls))
 	{
-		for(stringPairVector::const_iterator it =
-						m_settings[cls].begin();
-					it != m_settings[cls].end(); ++it)
+		for (const auto& setting : m_settings[cls]) 
 		{
-			if((*it).first == attribute)
+			if (setting.first == attribute)
 			{
-				return (*it).second ;
+				return setting.second;
 			}
 		}
 	}
-	static QString empty;
-	return empty;
+	return "";
 }
 
 

--- a/src/core/Controller.cpp
+++ b/src/core/Controller.cpp
@@ -25,7 +25,6 @@
  */
 
 #include <QDomElement>
-#include <QVector>
 
 
 #include "AudioEngine.h"
@@ -37,7 +36,7 @@
 
 
 long Controller::s_periods = 0;
-QVector<Controller *> Controller::s_controllers;
+ControllerVector Controller::s_controllers;
 
 
 
@@ -52,7 +51,7 @@ Controller::Controller( ControllerTypes _type, Model * _parent,
 {
 	if( _type != DummyController && _type != MidiController )
 	{
-		s_controllers.append( this );
+		s_controllers.push_back(this);
 		// Determine which name to use
 		for ( uint i=s_controllers.size(); ; i++ )
 		{
@@ -83,10 +82,10 @@ Controller::Controller( ControllerTypes _type, Model * _parent,
 
 Controller::~Controller()
 {
-	int idx = s_controllers.indexOf( this );
-	if( idx >= 0 )
+	auto it = std::find(s_controllers.begin(), s_controllers.end(), this);
+	if (it != s_controllers.end())
 	{
-		s_controllers.remove( idx );
+		s_controllers.erase(it);
 	}
 
 	m_valueBuffer.clear();

--- a/src/core/ControllerConnection.cpp
+++ b/src/core/ControllerConnection.cpp
@@ -50,7 +50,8 @@ ControllerConnection::ControllerConnection(Controller * _controller) :
 		m_controller = Controller::create( Controller::DummyController,
 									nullptr );
 	}
-	s_connections.append( this );
+
+	s_connections.push_back(this);
 }
 
 
@@ -61,7 +62,7 @@ ControllerConnection::ControllerConnection( int _controllerId ) :
 	m_controllerId( _controllerId ),
 	m_ownsController( false )
 {
-	s_connections.append( this );
+	s_connections.push_back(this);
 }
 
 
@@ -73,7 +74,13 @@ ControllerConnection::~ControllerConnection()
 	{
 		m_controller->removeConnection( this );
 	}
-	s_connections.remove( s_connections.indexOf( this ) );
+
+	auto posIt = std::find(s_connections.begin(), s_connections.end(), this);
+	if (posIt != s_connections.end()) 
+	{
+		s_connections.erase(posIt);
+	}
+	
 	if( m_ownsController )
 	{
 		delete m_controller;
@@ -183,10 +190,12 @@ void ControllerConnection::saveSettings( QDomDocument & _doc, QDomElement & _thi
 		}
 		else
 		{
-			int id = Engine::getSong()->controllers().indexOf( m_controller );
-			if( id >= 0 )
+			auto controllers = Engine::getSong()->controllers();
+			auto it = std::find(controllers.begin(), controllers.end(), m_controller);
+			if (it != controllers.end())
 			{
-				_this.setAttribute( "id", id );
+				int id = std::distance(controllers.begin(), it);
+				_this.setAttribute("id", id);
 			}
 		}
 	}

--- a/src/core/EffectChain.cpp
+++ b/src/core/EffectChain.cpp
@@ -53,7 +53,7 @@ EffectChain::~EffectChain()
 void EffectChain::saveSettings( QDomDocument & _doc, QDomElement & _this )
 {
 	m_enabledModel.saveSettings( _doc, _this, "enabled" );
-	_this.setAttribute( "numofeffects", m_effects.count() );
+	_this.setAttribute("numofeffects", static_cast<int>(m_effects.size()));
 
 	for( Effect* effect : m_effects)
 	{
@@ -121,7 +121,7 @@ void EffectChain::loadSettings( const QDomElement & _this )
 void EffectChain::appendEffect( Effect * _effect )
 {
 	Engine::audioEngine()->requestChangeInModel();
-	m_effects.append( _effect );
+	m_effects.push_back(_effect);
 	Engine::audioEngine()->doneChangeInModel();
 
 	m_enabledModel.setValue( true );
@@ -136,7 +136,7 @@ void EffectChain::removeEffect( Effect * _effect )
 {
 	Engine::audioEngine()->requestChangeInModel();
 
-	Effect ** found = std::find( m_effects.begin(), m_effects.end(), _effect );
+	auto found = std::find(m_effects.begin(), m_effects.end(), _effect);
 	if( found == m_effects.end() )
 	{
 		Engine::audioEngine()->doneChangeInModel();
@@ -146,7 +146,7 @@ void EffectChain::removeEffect( Effect * _effect )
 
 	Engine::audioEngine()->doneChangeInModel();
 
-	if( m_effects.isEmpty() )
+	if( m_effects.empty())
 	{
 		m_enabledModel.setValue( false );
 	}
@@ -159,9 +159,9 @@ void EffectChain::removeEffect( Effect * _effect )
 
 void EffectChain::moveDown( Effect * _effect )
 {
-	if( _effect != m_effects.last() )
+	if (_effect != m_effects.back())
 	{
-		int i = m_effects.indexOf(_effect);
+		int i = std::distance(m_effects.begin(), std::find(m_effects.begin(), m_effects.end(), _effect));
 		std::swap(m_effects[i + 1], m_effects[i]);
 	}
 }
@@ -171,9 +171,9 @@ void EffectChain::moveDown( Effect * _effect )
 
 void EffectChain::moveUp( Effect * _effect )
 {
-	if( _effect != m_effects.first() )
+	if(_effect != m_effects.front())
 	{
-		int i = m_effects.indexOf(_effect);
+		int i = std::distance(m_effects.begin(), std::find(m_effects.begin(), m_effects.end(), _effect));
 		std::swap(m_effects[i - 1], m_effects[i]);
 	}
 }
@@ -191,7 +191,7 @@ bool EffectChain::processAudioBuffer( sampleFrame * _buf, const fpp_t _frames, b
 	MixHelpers::sanitize( _buf, _frames );
 
 	bool moreEffects = false;
-	for( EffectList::Iterator it = m_effects.begin(); it != m_effects.end(); ++it )
+	for (auto it = m_effects.begin(); it != m_effects.end(); ++it)
 	{
 		if( hasInputNoise || ( *it )->isRunning() )
 		{
@@ -213,8 +213,7 @@ void EffectChain::startRunning()
 		return;
 	}
 
-	for( EffectList::Iterator it = m_effects.begin();
-						it != m_effects.end(); it++ )
+	for (auto it = m_effects.begin(); it != m_effects.end(); it++)
 	{
 		( *it )->startRunning();
 	}
@@ -229,9 +228,9 @@ void EffectChain::clear()
 
 	Engine::audioEngine()->requestChangeInModel();
 
-	while( m_effects.count() )
+	while (m_effects.size() > 0)
 	{
-		Effect * e = m_effects[m_effects.count() - 1];
+		Effect* e = m_effects[m_effects.size() - 1];
 		m_effects.pop_back();
 		delete e;
 	}

--- a/src/core/InstrumentFunctions.cpp
+++ b/src/core/InstrumentFunctions.cpp
@@ -173,14 +173,12 @@ bool InstrumentFunctionNoteStacking::Chord::hasSemiTone( int8_t semi_tone ) cons
 
 
 
-InstrumentFunctionNoteStacking::ChordTable::ChordTable() :
-	QVector<Chord>()
+InstrumentFunctionNoteStacking::ChordTable::ChordTable()
 {
-	for( int i = 0;
-		i < static_cast<int>( sizeof s_initTable / sizeof *s_initTable );
-		i++ )
+	int last = static_cast<int>(sizeof s_initTable / sizeof *s_initTable);
+	for (int i = 0; i < last; i++)
 	{
-		push_back( Chord( s_initTable[i].m_name, s_initTable[i].m_semiTones ) );
+		m_chords.push_back(Chord(s_initTable[i].m_name, s_initTable[i].m_semiTones));
 	}
 }
 
@@ -189,10 +187,10 @@ InstrumentFunctionNoteStacking::ChordTable::ChordTable() :
 
 const InstrumentFunctionNoteStacking::Chord & InstrumentFunctionNoteStacking::ChordTable::getByName( const QString & name, bool is_scale ) const
 {
-	for( int i = 0; i < size(); i++ )
+	for (int i = 0; i < m_chords.size(); i++)
 	{
-		if( at( i ).getName() == name && is_scale == at( i ).isScale() )
-			return at( i );
+		if (m_chords.at(i).getName() == name && is_scale == m_chords.at(i).isScale())
+			return m_chords.at(i);
 	}
 
 	static Chord empty;
@@ -209,9 +207,9 @@ InstrumentFunctionNoteStacking::InstrumentFunctionNoteStacking( Model * _parent 
 	m_chordRangeModel( 1.0f, 1.0f, 9.0f, 1.0f, this, tr( "Chord range" ) )
 {
 	const ChordTable & chord_table = ChordTable::getInstance();
-	for( int i = 0; i < chord_table.size(); ++i )
+	for (int i = 0; i < chord_table.chords().size(); ++i)
 	{
-		m_chordsModel.addItem( chord_table[i].getName() );
+		m_chordsModel.addItem(chord_table.chords()[i].getName());
 	}
 }
 
@@ -246,10 +244,10 @@ void InstrumentFunctionNoteStacking::processNote( NotePlayHandle * _n )
 			const int sub_note_key_base = base_note_key + octave_cnt * KeysPerOctave;
 
 			// process all notes in the chord
-			for( int i = 0; i < chord_table[selected_chord].size(); ++i )
+			for (int i = 0; i < chord_table.chords()[selected_chord].size(); ++i)
 			{
 				// add interval to sub-note-key
-				const int sub_note_key = sub_note_key_base + (int) chord_table[selected_chord][i];
+				const int sub_note_key = sub_note_key_base + static_cast<int>(chord_table.chords()[selected_chord][i]);
 				// maybe we're out of range -> let's get outta
 				// here!
 				if( sub_note_key > NumKeys )
@@ -311,9 +309,9 @@ InstrumentFunctionArpeggio::InstrumentFunctionArpeggio( Model * _parent ) :
 	m_arpModeModel( this, tr( "Arpeggio mode" ) )
 {
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
-	for( int i = 0; i < chord_table.size(); ++i )
+	for (int i = 0; i < chord_table.chords().size(); ++i)
 	{
-		m_arpModel.addItem( chord_table[i].getName() );
+		m_arpModel.addItem(chord_table.chords()[i].getName());
 	}
 
 	m_arpDirectionModel.addItem( tr( "Up" ), std::make_unique<PixmapLoader>( "arp_up" ) );
@@ -369,7 +367,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 	}
 
 	const InstrumentFunctionNoteStacking::ChordTable & chord_table = InstrumentFunctionNoteStacking::ChordTable::getInstance();
-	const int cur_chord_size = chord_table[selected_arp].size();
+	const int cur_chord_size = chord_table.chords()[selected_arp].size();
 	const int range = static_cast<int>(cur_chord_size * m_arpRangeModel.value() * m_arpRepeatsModel.value());
 	const int total_range = range * cnphv.size();
 
@@ -492,7 +490,7 @@ void InstrumentFunctionArpeggio::processNote( NotePlayHandle * _n )
 
 		// now calculate final key for our arp-note
 		const int sub_note_key = base_note_key + (cur_arp_idx / cur_chord_size ) *
-							KeysPerOctave + chord_table[selected_arp][cur_arp_idx % cur_chord_size];
+							KeysPerOctave + chord_table.chords()[selected_arp][cur_arp_idx % cur_chord_size];
 
 		// range-checking
 		if( sub_note_key >= NumKeys ||

--- a/src/core/PeakController.cpp
+++ b/src/core/PeakController.cpp
@@ -157,8 +157,7 @@ void PeakController::loadSettings( const QDomElement & _this )
 		effectId = m_loadCount++;
 	}
 
-	PeakControllerEffectVector::Iterator i;
-	for( i = s_effects.begin(); i != s_effects.end(); ++i )
+	for (auto i = s_effects.begin(); i != s_effects.end(); ++i)
 	{
 		if( (*i)->m_effectId == effectId )
 		{
@@ -186,14 +185,14 @@ PeakController * PeakController::getControllerBySetting(const QDomElement & _thi
 {
 	int effectId = _this.attribute( "effectId" ).toInt();
 
-	PeakControllerEffectVector::Iterator i;
+	PeakControllerEffectVector::iterator i;
 
 	//Backward compatibility for bug in <= 0.4.15 . For >= 1.0.0 ,
 	//foundCount should always be 1 because m_effectId is initialized with rand()
 	int foundCount = 0;
 	if( m_buggedFile == false )
 	{
-		for( i = s_effects.begin(); i != s_effects.end(); ++i )
+		for (auto i = s_effects.begin(); i != s_effects.end(); ++i)
 		{
 			if( (*i)->m_effectId == effectId )
 			{

--- a/src/core/RenderManager.cpp
+++ b/src/core/RenderManager.cpp
@@ -65,7 +65,7 @@ void RenderManager::renderNextTrack()
 {
 	m_activeRenderer.reset();
 
-	if( m_tracksToRender.isEmpty() )
+	if (m_tracksToRender.empty())
 	{
 		// nothing left to render
 		restoreMutedState();
@@ -167,7 +167,7 @@ void RenderManager::render(QString outputPath)
 // Unmute all tracks that were muted while rendering tracks
 void RenderManager::restoreMutedState()
 {
-	while( !m_unmuted.isEmpty() )
+	while (!m_unmuted.empty())
 	{
 		Track* restoreTrack = m_unmuted.back();
 		m_unmuted.pop_back();

--- a/src/core/Song.cpp
+++ b/src/core/Song.cpp
@@ -843,7 +843,9 @@ AutomationClip * Song::tempoAutomationClip()
 
 AutomatedValueMap Song::automatedValuesAt(TimePos time, int clipNum) const
 {
-	return TrackContainer::automatedValuesFromTracks(TrackList{m_globalAutomationTrack} << tracks(), time, clipNum);
+	TrackList trackList {m_globalAutomationTrack};
+	trackList.insert(trackList.end(), tracks().begin(), tracks().end());
+	return TrackContainer::automatedValuesFromTracks(trackList, time, clipNum);
 }
 
 
@@ -1318,7 +1320,7 @@ void Song::restoreControllerStates( const QDomElement & element )
 		else
 		{
 			// Fix indices to ensure correct connections
-			m_controllers.append(Controller::create(
+			m_controllers.push_back(Controller::create(
 				Controller::DummyController, this));
 		}
 
@@ -1437,9 +1439,10 @@ void Song::setProjectFileName(QString const & projectFileName)
 
 void Song::addController( Controller * controller )
 {
-	if( controller && !m_controllers.contains( controller ) )
+	const auto cont = std::find(m_controllers.begin(), m_controllers.end(), controller);
+	if (controller && cont == m_controllers.end())
 	{
-		m_controllers.append( controller );
+		m_controllers.push_back(controller);
 		emit controllerAdded( controller );
 
 		this->setModified();
@@ -1451,10 +1454,10 @@ void Song::addController( Controller * controller )
 
 void Song::removeController( Controller * controller )
 {
-	int index = m_controllers.indexOf( controller );
-	if( index != -1 )
+	auto it = std::find(m_controllers.begin(), m_controllers.end(), controller);
+	if (it != m_controllers.end())
 	{
-		m_controllers.remove( index );
+		m_controllers.erase(it);
 
 		emit controllerRemoved( controller );
 		delete controller;

--- a/src/core/Track.cpp
+++ b/src/core/Track.cpp
@@ -81,9 +81,9 @@ Track::~Track()
 	lock();
 	emit destroyedTrack();
 
-	while( !m_clips.isEmpty() )
+	while( !m_clips.empty() )
 	{
-		delete m_clips.last();
+		delete m_clips.back();
 	}
 
 	m_trackContainer->removeTrack( this );
@@ -363,9 +363,9 @@ void Track::removeClip( Clip * clip )
 /*! \brief Remove all Clips from this track */
 void Track::deleteClips()
 {
-	while( ! m_clips.isEmpty() )
+	while (!m_clips.empty())
 	{
-		delete m_clips.first();
+		delete m_clips.front();
 	}
 }
 

--- a/src/core/midi/MidiClient.cpp
+++ b/src/core/midi/MidiClient.cpp
@@ -75,8 +75,7 @@ void MidiClient::removePort( MidiPort* port )
 		return;
 	}
 
-	QVector<MidiPort *>::Iterator it =
-		std::find( m_midiPorts.begin(), m_midiPorts.end(), port );
+	auto it = std::find(m_midiPorts.begin(), m_midiPorts.end(), port);
 	if( it != m_midiPorts.end() )
 	{
 		m_midiPorts.erase( it );

--- a/src/gui/EffectRackView.cpp
+++ b/src/gui/EffectRackView.cpp
@@ -152,8 +152,7 @@ void EffectRackView::update()
 	QVector<bool> view_map( qMax<int>( fxChain()->m_effects.size(),
 						m_effectViews.size() ), false );
 
-	for( QVector<Effect *>::Iterator it = fxChain()->m_effects.begin();
-					it != fxChain()->m_effects.end(); ++it )
+	for (auto it = fxChain()->m_effects.begin(); it != fxChain()->m_effects.end(); ++it)
 	{
 		int i = 0;
 		for( QVector<EffectView *>::Iterator vit = m_effectViews.begin();

--- a/src/gui/MixerView.cpp
+++ b/src/gui/MixerView.cpp
@@ -428,8 +428,8 @@ void MixerView::deleteChannel(int index)
 void MixerView::deleteUnusedChannels()
 {
 	TrackContainer::TrackList tracks;
-	tracks += Engine::getSong()->tracks();
-	tracks += Engine::patternStore()->tracks();
+	tracks.insert(tracks.begin(), Engine::getSong()->tracks().begin(), Engine::getSong()->tracks().end());
+	tracks.insert(tracks.begin(), Engine::patternStore()->tracks().begin(), Engine::patternStore()->tracks().end());
 
 	std::vector<bool> inUse(m_mixerChannelViews.size(), false);
 
@@ -455,8 +455,7 @@ void MixerView::deleteUnusedChannels()
 	//Check all channels except master, delete those with no incoming sends
 	for(int i = m_mixerChannelViews.size()-1; i > 0; --i)
 	{
-		if (!inUse[i] && Engine::mixer()->mixerChannel(i)->m_receives.isEmpty())
-		{ deleteChannel(i); }
+		if (!inUse[i] && Engine::mixer()->mixerChannel(i)->m_receives.empty()) { deleteChannel(i); }
 	}
 }
 

--- a/src/gui/clips/AutomationClipView.cpp
+++ b/src/gui/clips/AutomationClipView.cpp
@@ -196,11 +196,11 @@ void AutomationClipView::constructContextMenu( QMenu * _cm )
 	_cm->addAction( embed::getIconPixmap( "flip_x" ),
 						tr( "Flip Horizontally (Visible)" ),
 						this, SLOT( flipX() ) );
-	if( !m_clip->m_objects.isEmpty() )
+	if (!m_clip->m_objects.empty())
 	{
 		_cm->addSeparator();
 		QMenu * m = new QMenu( tr( "%1 Connections" ).
-				arg( m_clip->m_objects.count() ), _cm );
+				arg(m_clip->m_objects.size()), _cm);
 		for( AutomationClip::objectVector::iterator it =
 						m_clip->m_objects.begin();
 					it != m_clip->m_objects.end(); ++it )

--- a/src/gui/clips/ClipView.cpp
+++ b/src/gui/clips/ClipView.cpp
@@ -541,7 +541,7 @@ DataFile ClipView::createClipDataFiles(
 	{
 		// Insert into the dom under the "clips" element
 		Track* clipTrack = ( *it )->m_trackView->getTrack();
-		int trackIndex = tc->tracks().indexOf( clipTrack );
+		int trackIndex = std::distance(tc->tracks().begin(), std::find(tc->tracks().begin(), tc->tracks().end(), clipTrack));
 		QDomElement clipElement = dataFile.createElement("clip");
 		clipElement.setAttribute( "trackIndex", trackIndex );
 		clipElement.setAttribute( "trackType", clipTrack->type() );
@@ -553,7 +553,7 @@ DataFile ClipView::createClipDataFiles(
 	dataFile.content().appendChild( clipParent );
 
 	// Add extra metadata needed for calculations later
-	int initialTrackIndex = tc->tracks().indexOf( t );
+	int initialTrackIndex = std::distance(tc->tracks().begin(), std::find(tc->tracks().begin(), tc->tracks().end(), t));
 	if( initialTrackIndex < 0 )
 	{
 		printf("Failed to find selected track in the TrackContainer.\n");

--- a/src/gui/editors/PianoRoll.cpp
+++ b/src/gui/editors/PianoRoll.cpp
@@ -397,7 +397,7 @@ PianoRoll::PianoRoll() :
 			InstrumentFunctionNoteStacking::ChordTable::getInstance();
 
 	m_scaleModel.addItem( tr("No scale") );
-	for( const InstrumentFunctionNoteStacking::Chord& chord : chord_table )
+	for (const InstrumentFunctionNoteStacking::Chord& chord : chord_table.chords())
 	{
 		if( chord.isScale() )
 		{
@@ -414,7 +414,7 @@ PianoRoll::PianoRoll() :
 
 	// Set up chord model
 	m_chordModel.addItem( tr("No chord") );
-	for( const InstrumentFunctionNoteStacking::Chord& chord : chord_table )
+	for (const InstrumentFunctionNoteStacking::Chord& chord : chord_table.chords())
 	{
 		if( ! chord.isScale() )
 		{
@@ -771,7 +771,7 @@ void PianoRoll::fitNoteLengths(bool fill)
 		{
 			if (!fill) { break; }
 			// Last notes stretch to end of last bar
-			length = notes.last()->endPos().nextFullBar() * TimePos::ticksPerBar() - note->pos();
+			length = notes.back()->endPos().nextFullBar() * TimePos::ticksPerBar() - note->pos();
 		}
 		else
 		{
@@ -1229,11 +1229,9 @@ void PianoRoll::shiftPos(NoteVector notes, int amount)
 {
 	m_midiClip->addJournalCheckPoint();
 
-	if (notes.isEmpty()) {
-		return;
-	}
+	if (notes.empty()) { return; }
 
-	auto leftMostPos = notes.first()->pos();
+	auto leftMostPos = notes.front()->pos();
 	//Limit leftwards shifts to prevent moving left of clip start
 	auto shiftAmount = (leftMostPos > -amount) ? amount : -leftMostPos;
 	if (shiftAmount == 0) { return; }
@@ -1624,7 +1622,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 		if (note)
 		{
-			n.append(note);
+			n.push_back(note);
 
 			updateKnifePos(me);
 
@@ -1702,7 +1700,7 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
+			auto it = notes.begin() + notes.size() - 1;
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -1825,9 +1823,9 @@ void PianoRoll::mousePressEvent(QMouseEvent * me )
 
 				auto selectedNotes = getSelectedNotes();
 
-				m_moveBoundaryLeft = selectedNotes.first()->pos().getTicks();
-				m_moveBoundaryRight = selectedNotes.first()->endPos();
-				m_moveBoundaryBottom = selectedNotes.first()->key();
+				m_moveBoundaryLeft = selectedNotes.front()->pos().getTicks();
+				m_moveBoundaryRight = selectedNotes.front()->endPos();
+				m_moveBoundaryBottom = selectedNotes.front()->key();
 				m_moveBoundaryTop = m_moveBoundaryBottom;
 
 				//Figure out the bounding box of all the selected notes
@@ -2015,7 +2013,7 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 		{
 			if( i->withinRange( ticks_start, ticks_end ) || ( i->selected() && !altPressed ) )
 			{
-				nv += i;
+				nv.push_back(i);
 			}
 		}
 		// make sure we're on a note
@@ -2033,7 +2031,7 @@ void PianoRoll::mouseDoubleClickEvent(QMouseEvent * me )
 					if( dist < closest_dist ) { closest = i; closest_dist = dist; }
 				}
 				// ... then remove all notes from the vector that aren't on the same exact time
-				NoteVector::Iterator it = nv.begin();
+				auto it = nv.begin();
 				while( it != nv.end() )
 				{
 					const Note *note = *it;
@@ -2496,7 +2494,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			bool altPressed = me->modifiers() & Qt::AltModifier;
 			// We iterate from last note in MIDI clip to the first,
 			// chronologically
-			NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
+			auto it = notes.begin() + notes.size() - 1;
 			for( int i = 0; i < notes.size(); ++i )
 			{
 				Note* n = *it;
@@ -2558,7 +2556,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			NoteVector::ConstIterator it = notes.begin()+notes.size()-1;
+			auto it = notes.begin() + notes.size() - 1;
 
 			// loop through whole note-vector...
 			for( int i = 0; i < notes.size(); ++i )
@@ -2635,7 +2633,7 @@ void PianoRoll::mouseMoveEvent( QMouseEvent * me )
 			const NoteVector & notes = m_midiClip->notes();
 
 			// will be our iterator in the following loop
-			NoteVector::ConstIterator it = notes.begin();
+			auto it = notes.begin();
 
 			// loop through whole note-vector...
 			while( it != notes.end() )
@@ -3768,7 +3766,7 @@ void PianoRoll::wheelEvent(QWheelEvent * we )
 		{
 			if( i->withinRange( ticks_start, ticks_end ) || ( i->selected() && !altPressed ) )
 			{
-				nv += i;
+				nv.push_back(i);
 			}
 		}
 		if( nv.size() > 0 )

--- a/src/gui/editors/TrackContainerView.cpp
+++ b/src/gui/editors/TrackContainerView.cpp
@@ -171,8 +171,8 @@ void TrackContainerView::moveTrackView( TrackView * trackView, int indexTo )
 
 	Track * track = m_tc->m_tracks[indexFrom];
 
-	m_tc->m_tracks.remove( indexFrom );
-	m_tc->m_tracks.insert( indexTo, track );
+	m_tc->m_tracks.erase(m_tc->m_tracks.begin() + indexFrom);
+	m_tc->m_tracks.insert(m_tc->m_tracks.begin() + indexTo, track);
 	m_trackViews.move( indexFrom, indexTo );
 
 	realignTracks();

--- a/src/gui/modals/ControllerConnectionDialog.cpp
+++ b/src/gui/modals/ControllerConnectionDialog.cpp
@@ -259,7 +259,8 @@ ControllerConnectionDialog::ControllerConnectionDialog( QWidget * _parent,
 			}
 			else
 			{
-				int idx = Engine::getSong()->controllers().indexOf( cc->getController() );
+				auto controllers = Engine::getSong()->controllers();
+				int idx = std::distance(controllers.begin(), std::find(controllers.begin(), controllers.end(), cc->getController()));
 
 				if( idx >= 0 )
 				{

--- a/src/gui/tracks/TrackContentWidget.cpp
+++ b/src/gui/tracks/TrackContentWidget.cpp
@@ -364,7 +364,7 @@ bool TrackContentWidget::canPasteSelection( TimePos clipPos, const QMimeData* md
 
 	// Get the current track's index
 	const TrackContainer::TrackList tracks = t->trackContainer()->tracks();
-	const int currentTrackIndex = tracks.indexOf( t );
+	const int currentTrackIndex = std::distance(tracks.begin(), std::find(tracks.begin(), tracks.end(), t));
 
 	// Don't paste if we're on the same bar and allowSameBar is false
 	auto sourceTrackContainerId = metadata.attributeNode( "trackContainerId" ).value().toUInt();
@@ -454,8 +454,8 @@ bool TrackContentWidget::pasteSelection( TimePos clipPos, const QMimeData * md, 
 
 	// Snap the mouse position to the beginning of the dropped bar, in ticks
 	const TrackContainer::TrackList tracks = getTrack()->trackContainer()->tracks();
-	const int currentTrackIndex = tracks.indexOf( getTrack() );
-
+	const int currentTrackIndex = std::distance(tracks.begin(), std::find(tracks.begin(), tracks.end(), getTrack()));
+	
 	bool wasSelection = m_trackView->trackContainerView()->rubberBand()->selectedObjects().count();
 
 	// Unselect the old group

--- a/src/tracks/InstrumentTrack.cpp
+++ b/src/tracks/InstrumentTrack.cpp
@@ -722,7 +722,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 
 	bool played_a_note = false;	// will be return variable
 
-	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
+	for (auto it = clips.begin(); it != clips.end(); ++it)
 	{
 		MidiClip* c = dynamic_cast<MidiClip*>( *it );
 		// everything which is not a MIDI clip won't be played
@@ -742,7 +742,7 @@ bool InstrumentTrack::play( const TimePos & _start, const fpp_t _frames,
 		// get all notes from the given clip...
 		const NoteVector & notes = c->notes();
 		// ...and set our index to zero
-		NoteVector::ConstIterator nit = notes.begin();
+		auto nit = notes.begin();
 
 		// very effective algorithm for playing notes that are
 		// posated within the current sample-frame

--- a/src/tracks/SampleTrack.cpp
+++ b/src/tracks/SampleTrack.cpp
@@ -131,7 +131,7 @@ bool SampleTrack::play( const TimePos & _start, const fpp_t _frames,
 		setPlaying(nowPlaying);
 	}
 
-	for( clipVector::Iterator it = clips.begin(); it != clips.end(); ++it )
+	for( auto it = clips.begin(); it != clips.end(); ++it )
 	{
 		SampleClip * st = dynamic_cast<SampleClip *>( *it );
 		if( !st->isMuted() )


### PR DESCRIPTION
Removes the remaining ``QVector`` from the core and makes the necessary changes to non-core components. I plan on doing a small reorganization of the core so it is easier to know what to change and what not to change.

I am submitting it to your original Qt removal PR. I do not think it is best to make distinct PRs for a single goal, but that is just me. This builds off of your QVector removal PR.

I have tested the code and it seems to compile and build. ~I still have to make some changes so that it complies with the CI tests,~ but the changes, I believe, are indeed functional and working.

Core components still in need of QVector removal:
- [x] ``ConfigManager``
